### PR TITLE
Changed the order of two endpoints to fix a bug in the code

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,18 +24,6 @@ app.get('/api/v1/pets', (req, res) => {
 
 });
 
-// get pet by name
-app.get('/api/v1/pets/:name', (req, res) => {
-    // get the name from the request
-
-
-    // find the pet in the pets array
-    const pet = pets.find(pet => pet.name === name);
-
-    // send the pet as a response
-
-});
-
 // get pet by owner with query string
 app.get('/api/v1/pets/owner', (req, res) => {
     // get the owner from the request
@@ -43,6 +31,18 @@ app.get('/api/v1/pets/owner', (req, res) => {
 
     // find the pet in the pets array
     const pet = pets.find(pet => pet.owner === owner);
+
+    // send the pet as a response
+
+});
+
+// get pet by name
+app.get('/api/v1/pets/:name', (req, res) => {
+    // get the name from the request
+
+
+    // find the pet in the pets array
+    const pet = pets.find(pet => pet.name === name);
 
     // send the pet as a response
 


### PR DESCRIPTION
The current order of the starter code endpoints has the /api/v1/pets/:name endpoint overshadowing the /api/v1/pets/owner endpoint so that it's unreachable. This PR fixes it.